### PR TITLE
Fix getting IP address with renamed get_ip_addresses method

### DIFF
--- a/components/hmlgw/HmlgwComponent.cpp
+++ b/components/hmlgw/HmlgwComponent.cpp
@@ -473,15 +473,19 @@ void HmlgwComponent::send_bidcos_frame(uint8_t counter, uint8_t destination, uin
 void HmlgwComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "HMLGW Server:");
     ESP_LOGCONFIG(TAG, "  Address: %s:%u",
-#if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2024, 3, 0)
                   esphome::network::get_ip_addresses()[0].str().c_str(),
+#elif ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
+                  esphome::network::get_ip_address().str().c_str(),
 #else
                   network_get_address().c_str(),
 #endif
                   this->port_);
     ESP_LOGCONFIG(TAG, "  KeepAlive: %s:%u",
-#if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2024, 3, 0)
                   esphome::network::get_ip_addresses()[0].str().c_str(),
+#elif ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
+                  esphome::network::get_ip_address().str().c_str(),
 #else
                   network_get_address().c_str(),
 #endif

--- a/components/hmlgw/HmlgwComponent.cpp
+++ b/components/hmlgw/HmlgwComponent.cpp
@@ -474,14 +474,14 @@ void HmlgwComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "HMLGW Server:");
     ESP_LOGCONFIG(TAG, "  Address: %s:%u",
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
-                  esphome::network::get_ip_addresses()[0].str(),
+                  esphome::network::get_ip_addresses()[0].str().c_str(),
 #else
                   network_get_address().c_str(),
 #endif
                   this->port_);
     ESP_LOGCONFIG(TAG, "  KeepAlive: %s:%u",
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
-                  esphome::network::get_ip_addresses()[0].str(),
+                  esphome::network::get_ip_addresses()[0].str().c_str(),
 #else
                   network_get_address().c_str(),
 #endif

--- a/components/hmlgw/HmlgwComponent.cpp
+++ b/components/hmlgw/HmlgwComponent.cpp
@@ -474,14 +474,14 @@ void HmlgwComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "HMLGW Server:");
     ESP_LOGCONFIG(TAG, "  Address: %s:%u",
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
-                  esphome::network::get_ip_address().str().c_str(),
+                  esphome::network::get_ip_addresses().str().c_str(),
 #else
                   network_get_address().c_str(),
 #endif
                   this->port_);
     ESP_LOGCONFIG(TAG, "  KeepAlive: %s:%u",
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
-                  esphome::network::get_ip_address().str().c_str(),
+                  esphome::network::get_ip_addresses().str().c_str(),
 #else
                   network_get_address().c_str(),
 #endif

--- a/components/hmlgw/HmlgwComponent.cpp
+++ b/components/hmlgw/HmlgwComponent.cpp
@@ -474,14 +474,14 @@ void HmlgwComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "HMLGW Server:");
     ESP_LOGCONFIG(TAG, "  Address: %s:%u",
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
-                  esphome::network::get_ip_addresses().str().c_str(),
+                  esphome::network::get_ip_addresses()[0].str(),
 #else
                   network_get_address().c_str(),
 #endif
                   this->port_);
     ESP_LOGCONFIG(TAG, "  KeepAlive: %s:%u",
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2021, 10, 0)
-                  esphome::network::get_ip_addresses().str().c_str(),
+                  esphome::network::get_ip_addresses()[0].str(),
 #else
                   network_get_address().c_str(),
 #endif


### PR DESCRIPTION
ESPHome has change the esphome::network:get_ip_address() method to work with ipv6 as well as ipv4. The new name of the method is get_ip_addresses().

I changed the name and access to the returned array to work again with current versions of ESPHome.